### PR TITLE
Fix issue when "Use Baked Audio" is checked

### DIFF
--- a/Assets/Scripts/AudioAnalyzer/AudioAnalyzer.cs
+++ b/Assets/Scripts/AudioAnalyzer/AudioAnalyzer.cs
@@ -64,6 +64,12 @@ public class AudioAnalyzer : MonoBehaviour
 			useBakedAudio = true;
 		}
 
+		if (useBakedAudio && clip != null) {
+			source.Stop();
+			source.clip = clip;
+			source.Play();
+		}
+
 		StartCoroutine(ManageBuffer());
     }
 


### PR DESCRIPTION
When "Use Baked Audio" is checked at the start, `clip` doesn't start.
